### PR TITLE
Update CMakeLists.txt to compile with Ubuntu 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 project(scream)
 
 set(CMAKE_CXX_STANDARD 20)
 add_compile_options(-Wall -O0 -march=native -mavx2 -ftree-vectorize)
+add_link_options(-pthread)
 
 add_executable(scream_server
         main_server.cpp


### PR DESCRIPTION
Without the proposed changes, CMakeLists.txt work on Ubuntu 22.04 but not on Ubuntu 20.04